### PR TITLE
Content deduplication for session archives

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -89,7 +89,7 @@ Automatic persistent memory that survives context limits and session boundaries:
 - [ ] Memory importance scoring (information density, decision count, topic novelty)
 - [ ] Memory consolidation (synthesize patterns across related conversations)
 - [ ] Forgetting curve (boost frequently-recalled memories, decay stale ones)
-- [ ] Content deduplication (detect and skip re-archived sessions)
+- [x] Content deduplication (detect and skip re-archived sessions)
 - [ ] Retention policies (auto-compress old memories >30 days)
 
 ### Schema & Search
@@ -99,7 +99,7 @@ Automatic persistent memory that survives context limits and session boundaries:
 - [ ] Ranked tag search (weight exact matches higher than partial)
 
 ### Developer Experience
-- [ ] Memory dashboard (web UI or TUI to browse/search/manage)
+- [x] Memory dashboard (TUI to browse/search/manage)
 - [ ] Export/import (backup and migration between machines)
 - [ ] Privacy controls (mark memories as "do not recall", auto-redact secrets)
 - [ ] Documentation and examples

--- a/rlm/db.py
+++ b/rlm/db.py
@@ -151,6 +151,18 @@ def source_name_exists(source_name: str) -> bool:
     return row is not None
 
 
+def find_entries_by_source_name(source_name: str) -> list[dict]:
+    """Find all entries with a given source_name (metadata only, no content)."""
+    conn = _get_conn()
+    rows = conn.execute(
+        """SELECT id, summary, tags, timestamp, source, source_name, char_count
+           FROM entries WHERE source_name = ?
+           ORDER BY timestamp DESC""",
+        (source_name,),
+    ).fetchall()
+    return [_row_to_index_dict(row) for row in rows]
+
+
 def get_entry(entry_id: str) -> dict | None:
     """Load a full memory entry by ID. Returns None if not found."""
     conn = _get_conn()


### PR DESCRIPTION
## Summary
- Uses session JSONL filename as stable identifier to detect duplicate archives
- Skips archiving if file is unchanged since last archive (exact size match via marker file)
- Replaces old entries and re-archives when session file has grown (always captures latest content)
- Replaces subprocess `_store_memory()` with direct `memory.add_memory()` calls for proper `source`/`source_name` tracking

## Changes
- `rlm/db.py`: Added `find_entries_by_source_name()` query
- `rlm/archive.py`: Added dedup check, marker file size tracking, switched to direct API calls
- `PROJECT.md`: Checked off content deduplication + TUI dashboard items

## Test plan
- [ ] Archive a session → verify entries have `source_name` set to JSONL filename
- [ ] Re-run archive on unchanged file → verify it skips with "already archived" message
- [ ] Modify session file → re-run → verify old entries replaced with new ones
- [ ] Verify `rlm tui` still displays entries correctly

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)