### PR TITLE
Fix hooks to read transcript_path from stdin

### DIFF
--- a/hooks/pre-compact-rlm-semantic.py
+++ b/hooks/pre-compact-rlm-semantic.py
@@ -3,8 +3,10 @@
 RLM PreCompact Hook — Archive conversation before compaction.
 
 Uses two-tier storage: summary entry (for fast recall) + full transcript (for drill-down).
+Reads transcript_path and cwd from stdin JSON provided by Claude Code.
 """
 
+import json
 import sys
 from pathlib import Path
 
@@ -15,14 +17,35 @@ sys.path.insert(0, str(RLM_PROJECT))
 from rlm.archive import get_session_file, mark_as_archived, archive_session
 
 
+def parse_hook_input() -> dict:
+    """Read the JSON hook input from stdin."""
+    try:
+        return json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+
+
 def main():
     try:
-        session_file = get_session_file()
+        hook_input = parse_hook_input()
+
+        # Get session file from stdin transcript_path (reliable), or fall back
+        session_file = None
+        path = hook_input.get("transcript_path")
+        if path:
+            p = Path(path)
+            if p.exists():
+                session_file = p
+
+        if not session_file:
+            session_file = get_session_file()
+
         if not session_file:
             print("[RLM-PreCompact] No session file found", file=sys.stderr)
             sys.exit(0)
 
-        if archive_session(session_file, hook_name="RLM-PreCompact"):
+        cwd = hook_input.get("cwd")
+        if archive_session(session_file, hook_name="RLM-PreCompact", cwd=cwd):
             mark_as_archived(session_file)
 
     except Exception as err:

--- a/rlm/archive.py
+++ b/rlm/archive.py
@@ -21,16 +21,17 @@ def log(prefix: str, msg: str):
     print(f"[{prefix}] {msg}", file=sys.stderr)
 
 
-def get_project_name() -> str:
+def get_project_name(cwd: str | None = None) -> str:
     """Get current project directory name from git root, or cwd."""
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
             capture_output=True, text=True, check=True,
+            cwd=cwd,
         )
         return Path(result.stdout.strip()).name
     except subprocess.CalledProcessError:
-        return Path.cwd().name
+        return Path(cwd).name if cwd else Path.cwd().name
 
 
 def get_session_file() -> Path | None:
@@ -66,7 +67,7 @@ def _store_memory(content: str, tags: str, summary: str):
     )
 
 
-def archive_session(session_file: Path, hook_name: str = "Archive"):
+def archive_session(session_file: Path, hook_name: str = "Archive", cwd: str | None = None):
     """Export, compress, summarize, and store a session as two memory entries.
 
     Args:
@@ -80,7 +81,7 @@ def archive_session(session_file: Path, hook_name: str = "Archive"):
     from rlm.semantic_tags import extract_semantic_tags, combine_tags
     from rlm.summarize import generate_summary
 
-    project_name = get_project_name()
+    project_name = get_project_name(cwd=cwd)
     session_id = f"s_{uuid.uuid4().hex[:8]}"
     timestamp = datetime.now().strftime("%Y-%m-%d")
 


### PR DESCRIPTION
## Summary
- Hooks now read `transcript_path` and `cwd` from stdin JSON provided by Claude Code, instead of using `get_session_file()` which grabbed the wrong session file when multiple projects are open
- `archive_session()` accepts a `cwd` parameter so `get_project_name()` resolves the correct project directory
- Falls back to the old `get_session_file()` behavior if stdin doesn't provide a path

Fixes #4

## Test plan
- [x] Verified hooks parse stdin JSON correctly when run manually with `echo '{"transcript_path": "...", "cwd": "..."}' | python hooks/pre-compact-rlm-semantic.py`
- [x] Confirmed cross-project archival tags the correct project name (e.g., "evereve-infra" instead of "recursive-ai")
- [x] Verified graceful fallback when stdin is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)