### PR TITLE
feat: archive active session with `rlm remember` (no args)

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -60,6 +60,9 @@ def handle_tool_call(name: str, arguments: dict) -> str:
         content = arguments.get("content", "")
         tags = arguments.get("tags", "")
         summary = arguments.get("summary", "")
+        if not content:
+            # No content: archive the current active session
+            return run_rlm("remember")
         cmd = ["remember", content]
         if tags:
             cmd += ["--tags", tags]
@@ -140,14 +143,15 @@ TOOLS = [
         "description": (
             "Store a piece of knowledge or decision in RLM persistent memory for future recall. "
             "Use this to save important findings, architectural decisions, or context that "
-            "should survive across sessions. Provide descriptive tags and a clear summary."
+            "should survive across sessions. Provide descriptive tags and a clear summary. "
+            "If called with no content, archives the current active Claude Code session on demand."
         ),
         "inputSchema": {
             "type": "object",
             "properties": {
                 "content": {
                     "type": "string",
-                    "description": "The content to store in memory",
+                    "description": "The content to store in memory. If omitted, archives the current active session.",
                 },
                 "tags": {
                     "type": "string",
@@ -158,7 +162,7 @@ TOOLS = [
                     "description": "Short description of what this memory contains (under 80 chars)",
                 },
             },
-            "required": ["content"],
+            "required": [],
         },
     },
     {

--- a/rlm/cli.py
+++ b/rlm/cli.py
@@ -5,9 +5,10 @@ All stdout is capped at 4000 chars with truncation notice.
 
 import argparse
 import json
+import os
 import sys
 
-from rlm import scanner, chunker, extractor, state, memory, export, url_fetcher
+from rlm import scanner, chunker, extractor, state, memory, export, url_fetcher, archive
 
 MAX_OUTPUT = 4000
 
@@ -238,8 +239,17 @@ def cmd_remember(args):
         source = "text"
         source_name = None
     else:
-        _print("Error: Provide content, a URL, --file PATH, or --stdin")
-        sys.exit(1)
+        # No args: archive the current active Claude Code session
+        session_file = archive.get_session_file()
+        if session_file is None:
+            _print("Error: No active Claude Code session found. Provide content, a URL, --file PATH, or --stdin")
+            sys.exit(1)
+        result = archive.archive_session(session_file, hook_name="Manual", cwd=os.getcwd())
+        if result:
+            _print(f"Session archived: {session_file.name}")
+        else:
+            _print(f"Session already archived (unchanged): {session_file.name}")
+        return
 
     if not content.strip():
         _print("Error: Empty content")

--- a/tests/test_cli_remember.py
+++ b/tests/test_cli_remember.py
@@ -1,0 +1,97 @@
+"""Tests for `rlm remember` no-args session archival path."""
+
+import argparse
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Use a temporary database for tests
+_test_db_dir = tempfile.mkdtemp(prefix="rlm-test-remember-")
+os.environ.setdefault("RLM_MEMORY_DIR", _test_db_dir)
+
+import rlm.db as db_mod
+db_mod.MEMORY_DIR = _test_db_dir
+db_mod.DB_PATH = os.path.join(_test_db_dir, "memory.db")
+
+from rlm.cli import cmd_remember
+
+
+def _make_args(**kwargs):
+    """Build an argparse.Namespace with remember defaults."""
+    defaults = {
+        "content": None,
+        "file": None,
+        "url": None,
+        "stdin": False,
+        "tags": None,
+        "summary": None,
+        "depth": 2,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+class TestRememberNoArgs(unittest.TestCase):
+    """Test the no-args path that archives the active session."""
+
+    @patch("rlm.cli.archive")
+    def test_no_args_calls_archive_session(self, mock_archive):
+        """No args should find and archive the active session."""
+        fake_path = Path("/tmp/fake-session.jsonl")
+        mock_archive.get_session_file.return_value = fake_path
+        mock_archive.archive_session.return_value = True
+
+        with patch("builtins.print") as mock_print:
+            cmd_remember(_make_args())
+
+        mock_archive.get_session_file.assert_called_once()
+        mock_archive.archive_session.assert_called_once_with(
+            fake_path, hook_name="Manual", cwd=os.getcwd(),
+        )
+        output = mock_print.call_args[0][0]
+        assert "Session archived" in output
+
+    @patch("rlm.cli.archive")
+    def test_no_args_already_archived(self, mock_archive):
+        """When dedup kicks in, should print 'already archived'."""
+        fake_path = Path("/tmp/fake-session.jsonl")
+        mock_archive.get_session_file.return_value = fake_path
+        mock_archive.archive_session.return_value = False
+
+        with patch("builtins.print") as mock_print:
+            cmd_remember(_make_args())
+
+        output = mock_print.call_args[0][0]
+        assert "already archived" in output.lower()
+
+    @patch("rlm.cli.archive")
+    def test_no_args_no_session_file(self, mock_archive):
+        """When no active session exists, should print error and exit."""
+        mock_archive.get_session_file.return_value = None
+
+        with patch("builtins.print"), self.assertRaises(SystemExit) as ctx:
+            cmd_remember(_make_args())
+
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_content_arg_still_works(self):
+        """Providing content should take the normal store path, not the archive path."""
+        with patch("rlm.cli.memory") as mock_memory:
+            mock_memory.add_memory.return_value = {
+                "id": "m_test",
+                "summary": "test",
+                "tags": ["t"],
+                "char_count": 5,
+            }
+            with patch("builtins.print") as mock_print:
+                cmd_remember(_make_args(content="hello world"))
+
+            mock_memory.add_memory.assert_called_once()
+            output = mock_print.call_args[0][0]
+            assert "Memory stored" in output
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `rlm remember` with no arguments now archives the current active Claude Code session on demand — same two-tier archival (summary + transcript + facts) as the PreCompact/SessionEnd hooks
- `rlm_remember` MCP tool works the same way when `content` is omitted
- Dedup prevents double-archiving unchanged sessions ("already archived" message)

Closes #39

## Changes
- **`rlm/cli.py`**: Added no-args path in `cmd_remember()` that calls `archive.archive_session()`
- **`mcp/server.py`**: Made `content` optional in `rlm_remember` tool schema; empty content triggers `rlm remember` with no positional arg
- **`tests/test_cli_remember.py`**: 4 tests covering archive success, dedup, no-session error, and existing content path

## Test plan
- [x] All 57 tests pass (`uv run python -m unittest discover tests -v`)
- [ ] `uv run rlm remember` with active session → archives it
- [ ] Run again immediately → "already archived"
- [ ] `uv run rlm remember "some text"` → still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)