### PR TITLE
Add OpenCode support to RLM

### DIFF
--- a/install-opencode.sh
+++ b/install-opencode.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Install the RLM plugin for OpenCode.
+#
+# Three steps:
+# 1. uv sync (Python dependencies)
+# 2. Copy plugin to ~/.config/opencode/plugins/ with RLM_ROOT substituted
+# 3. Register MCP server in ~/.config/opencode/opencode.json
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OPENCODE_CONFIG_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+PLUGINS_DIR="$OPENCODE_CONFIG_DIR/plugins"
+CONFIG_FILE="$OPENCODE_CONFIG_DIR/opencode.json"
+
+echo "Installing RLM for OpenCode..."
+echo "  RLM root: $SCRIPT_DIR"
+echo "  Config:   $OPENCODE_CONFIG_DIR"
+
+# --- Step 1: Python dependencies ---
+if ! command -v uv &>/dev/null; then
+    echo "uv not found. Installing..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    export PATH="$HOME/.cargo/bin:$PATH"
+fi
+
+echo ""
+echo "Step 1/3: Installing Python dependencies..."
+cd "$SCRIPT_DIR"
+uv sync
+
+# --- Step 2: Install plugin ---
+echo ""
+echo "Step 2/3: Installing OpenCode plugin..."
+mkdir -p "$PLUGINS_DIR"
+
+# Copy plugin with __RLM_ROOT__ substituted
+sed "s|__RLM_ROOT__|${SCRIPT_DIR}|g" \
+    "$SCRIPT_DIR/opencode/rlm-plugin.ts" \
+    > "$PLUGINS_DIR/rlm-plugin.ts"
+
+echo "  Plugin installed: $PLUGINS_DIR/rlm-plugin.ts"
+
+# --- Step 3: Register MCP server ---
+echo ""
+echo "Step 3/3: Registering MCP server..."
+
+# Create config file if it doesn't exist
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo '{}' > "$CONFIG_FILE"
+fi
+
+# Check if jq is available for JSON manipulation
+if command -v jq &>/dev/null; then
+    # Use jq to merge MCP config
+    MCP_CONFIG=$(jq -n \
+        --arg project "$SCRIPT_DIR" \
+        '{
+            mcp: {
+                rlm: {
+                    type: "local",
+                    command: ["uv", "run", "--project", $project, "python", "mcp/server.py"]
+                }
+            }
+        }')
+
+    # Merge into existing config (preserving other settings)
+    jq -s '.[0] * .[1]' "$CONFIG_FILE" <(echo "$MCP_CONFIG") > "${CONFIG_FILE}.tmp"
+    mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
+    echo "  MCP server registered in $CONFIG_FILE"
+else
+    # Fallback: check if already configured, otherwise warn
+    if grep -q '"rlm"' "$CONFIG_FILE" 2>/dev/null; then
+        echo "  MCP server already configured in $CONFIG_FILE"
+    else
+        echo ""
+        echo "  Warning: jq not found. Please add the following to $CONFIG_FILE manually:"
+        echo ""
+        echo "  {"
+        echo "    \"mcp\": {"
+        echo "      \"rlm\": {"
+        echo "        \"type\": \"local\","
+        echo "        \"command\": [\"uv\", \"run\", \"--project\", \"$SCRIPT_DIR\", \"python\", \"mcp/server.py\"]"
+        echo "      }"
+        echo "    }"
+        echo "  }"
+        echo ""
+    fi
+fi
+
+# --- Done ---
+echo ""
+echo "Done! RLM is now installed for OpenCode."
+echo ""
+echo "Features:"
+echo "  - Context injection: previous session memories in system prompt"
+echo "  - Auto-archival: sessions archived on compaction and idle"
+echo "  - MCP tools: rlm_recall, rlm_remember, rlm_memory_list,"
+echo "               rlm_memory_extract, rlm_forget"
+echo ""
+echo "To verify: start OpenCode and check 'opencode mcp list' for rlm"

--- a/opencode/rlm-plugin.ts
+++ b/opencode/rlm-plugin.ts
@@ -1,0 +1,145 @@
+/**
+ * RLM Plugin for OpenCode
+ *
+ * Provides persistent memory integration via three hooks:
+ * 1. System prompt injection — context from previous sessions
+ * 2. Session compacting — archive before compaction
+ * 3. Session idle — archive when agent stops responding
+ *
+ * This is a thin JS/TS bridge that shells out to the Python CLI.
+ */
+import type { Plugin } from "@opencode-ai/plugin";
+
+// Substituted by install-opencode.sh — absolute path to the RLM project root
+const RLM_ROOT = "__RLM_ROOT__";
+
+// Cache duration for system context injection (5 minutes)
+const CONTEXT_CACHE_TTL_MS = 5 * 60 * 1000;
+
+// Dedup guard: skip archival if same session archived within 60 seconds
+const ARCHIVE_DEDUP_WINDOW_MS = 60 * 1000;
+
+export const RlmPlugin: Plugin = async ({ $, directory }) => {
+  // --- State ---
+  let cachedContext: string | null = null;
+  let contextCachedAt = 0;
+  const archiveTimestamps = new Map<string, number>();
+
+  /**
+   * Run an RLM CLI command and return stdout.
+   * Uses uv run to ensure the correct Python environment.
+   */
+  async function rlm(...args: string[]): Promise<string> {
+    const result = await $`uv run --project ${RLM_ROOT} rlm ${args}`.text();
+    return result.trim();
+  }
+
+  /**
+   * Get the project name from the current directory for tag filtering.
+   */
+  function getProjectTag(): string {
+    const parts = directory.split("/");
+    return parts[parts.length - 1] || "unknown";
+  }
+
+  /**
+   * Check if we should skip archival (dedup guard).
+   */
+  function shouldSkipArchival(sessionId: string): boolean {
+    const lastArchived = archiveTimestamps.get(sessionId);
+    if (lastArchived && Date.now() - lastArchived < ARCHIVE_DEDUP_WINDOW_MS) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Archive an OpenCode session via the CLI.
+   */
+  async function archiveSession(sessionId: string): Promise<void> {
+    if (shouldSkipArchival(sessionId)) {
+      return;
+    }
+
+    try {
+      // Use opencode CLI to export the session, then pipe to rlm archive
+      const exportJson = await $`opencode session export ${sessionId}`
+        .quiet()
+        .nothrow()
+        .text();
+
+      if (!exportJson.trim()) {
+        return;
+      }
+
+      // Write to temp file and archive
+      const tmpFile = `/tmp/rlm-opencode-${sessionId}.json`;
+      await Bun.write(tmpFile, exportJson);
+
+      await $`uv run --project ${RLM_ROOT} rlm archive-opencode ${tmpFile} --cwd ${directory}`
+        .quiet()
+        .nothrow();
+
+      // Clean up temp file
+      await $`rm -f ${tmpFile}`.quiet().nothrow();
+
+      archiveTimestamps.set(sessionId, Date.now());
+    } catch {
+      // Non-fatal — don't crash the session
+    }
+  }
+
+  return {
+    /**
+     * Inject RLM context into the system prompt.
+     * Cached for 5 minutes to avoid re-running on every message.
+     */
+    "experimental.chat.system.transform": async ({ output }) => {
+      try {
+        const now = Date.now();
+        if (!cachedContext || now - contextCachedAt > CONTEXT_CACHE_TTL_MS) {
+          const project = getProjectTag();
+          cachedContext = await rlm(
+            "memory-list",
+            "--tags",
+            `conversation,${project}`,
+            "--limit",
+            "10",
+          );
+          contextCachedAt = now;
+        }
+
+        if (cachedContext) {
+          output.system.push(
+            `\n## RLM Memory Context\nRelevant memories from previous sessions:\n\n${cachedContext}`,
+          );
+        }
+      } catch {
+        // Non-fatal — context injection is best-effort
+      }
+    },
+
+    /**
+     * Archive session before compaction.
+     */
+    "experimental.session.compacting": async ({ input }) => {
+      const sessionId = input.sessionID || input.session_id;
+      if (sessionId) {
+        await archiveSession(sessionId);
+      }
+    },
+
+    /**
+     * Archive session when agent goes idle (with dedup guard).
+     */
+    event: async ({ event }) => {
+      if (event.type === "session.idle") {
+        const sessionId =
+          (event as any).sessionID || (event as any).session_id;
+        if (sessionId) {
+          await archiveSession(sessionId);
+        }
+      }
+    },
+  };
+};

--- a/rlm/archive.py
+++ b/rlm/archive.py
@@ -14,6 +14,7 @@ summary generation, facts extraction) to work with ANY content type,
 not just .jsonl session files.
 """
 
+import json
 import subprocess
 import sys
 import uuid
@@ -323,5 +324,71 @@ def archive_session(session_file: Path, hook_name: str = "Archive", cwd: str | N
 
     # Update marker with current file size
     mark_as_archived(session_file, file_size=current_file_size)
+
+    return True
+
+
+def archive_opencode_session(json_path: str, hook_name: str = "OpenCode", cwd: str | None = None):
+    """Export, compress, and store an OpenCode session via the smart remember pipeline.
+
+    Deduplication is DB-level via source_name (the OpenCode session ID).
+    No marker files needed — the session ID is stable across re-exports.
+
+    Args:
+        json_path: Path to the OpenCode session export JSON file.
+        hook_name: Log prefix (e.g., "OpenCode", "OpenCode-Compact").
+        cwd: Working directory for project name detection.
+
+    Returns:
+        True if archival succeeded, False otherwise.
+    """
+    from rlm.opencode_export import export_opencode_session, get_session_id, get_session_directory
+
+    memory.init_memory_store()
+
+    # Parse JSON to get session metadata
+    with open(json_path, "r") as f:
+        data = json.load(f)
+
+    opencode_session_id = get_session_id(data)
+    if not opencode_session_id:
+        log(hook_name, "No session ID found in export — skipping")
+        return False
+
+    # Use session ID as source_name for dedup
+    source_name = f"opencode:{opencode_session_id}"
+
+    # Get project name from cwd, JSON directory, or fallback
+    project_dir = cwd or get_session_directory(data)
+    project_name = get_project_name(cwd=project_dir) if project_dir else "unknown"
+
+    session_id = f"s_{uuid.uuid4().hex[:8]}"
+    timestamp = datetime.now().strftime("%Y-%m-%d")
+
+    log(hook_name, f"Archiving OpenCode session {opencode_session_id[:12]}...")
+    log(hook_name, f"Project: {project_name}, Session ID: {session_id}")
+
+    # Export directly via Python (no subprocess needed)
+    transcript = export_opencode_session(json_path)
+
+    if not transcript or not transcript.strip():
+        log(hook_name, "Empty transcript — skipping")
+        return False
+
+    # Run through smart pipeline with dedup enabled
+    base_tags = ["conversation", "session", "opencode", project_name, timestamp, session_id]
+    label = f"Session: {project_name} on {timestamp} (OpenCode)"
+
+    smart_remember(
+        content=transcript,
+        source="session",
+        source_name=source_name,
+        user_tags=base_tags,
+        label=label,
+        dedup=True,  # DB-level dedup via source_name
+        log_prefix=hook_name,
+    )
+
+    log(hook_name, f"Archived to ~/.rlm/memory/ (session: {session_id})")
 
     return True

--- a/rlm/archive.py
+++ b/rlm/archive.py
@@ -342,7 +342,10 @@ def archive_opencode_session(json_path: str, hook_name: str = "OpenCode", cwd: s
     Returns:
         True if archival succeeded, False otherwise.
     """
-    from rlm.opencode_export import export_opencode_session, get_session_id, get_session_directory
+    from rlm.opencode_export import (
+        export_opencode_session, get_session_id, get_session_directory,
+        _parse_opencode_messages,
+    )
 
     memory.init_memory_store()
 
@@ -353,6 +356,12 @@ def archive_opencode_session(json_path: str, hook_name: str = "OpenCode", cwd: s
     opencode_session_id = get_session_id(data)
     if not opencode_session_id:
         log(hook_name, "No session ID found in export — skipping")
+        return False
+
+    # Check for actual messages before doing expensive export
+    parsed = _parse_opencode_messages(data)
+    if not parsed:
+        log(hook_name, "No messages in export — skipping")
         return False
 
     # Use session ID as source_name for dedup

--- a/rlm/cli.py
+++ b/rlm/cli.py
@@ -8,7 +8,7 @@ import json
 import os
 import sys
 
-from rlm import scanner, chunker, extractor, state, memory, export, url_fetcher, archive
+from rlm import scanner, chunker, extractor, state, memory, export, opencode_export, url_fetcher, archive
 
 MAX_OUTPUT = 4000
 
@@ -629,6 +629,30 @@ def cmd_export_session(args):
         print(text)
 
 
+def cmd_export_opencode(args):
+    """Export an OpenCode session JSON to readable transcript."""
+    output_path = args.output if args.output else None
+    text = opencode_export.export_opencode_session(args.json_file, output_path=output_path)
+
+    if output_path:
+        _print(f"Exported to {output_path} ({len(text):,} chars)")
+    else:
+        print(text)
+
+
+def cmd_archive_opencode(args):
+    """Archive an OpenCode session export to RLM memory."""
+    result = archive.archive_opencode_session(
+        json_path=args.json_file,
+        hook_name="ArchiveOpenCode",
+        cwd=args.cwd,
+    )
+    if result:
+        _print(f"OpenCode session archived: {args.json_file}")
+    else:
+        _print(f"OpenCode session skipped (empty or already archived): {args.json_file}")
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="rlm",
@@ -775,6 +799,18 @@ def main():
     p_export.add_argument("session_file", help="Path to Claude Code .jsonl session file")
     p_export.add_argument("--output", help="Write to file instead of stdout")
     p_export.set_defaults(func=cmd_export_session)
+
+    # export-opencode
+    p_export_oc = subparsers.add_parser("export-opencode", help="Export OpenCode session JSON to transcript")
+    p_export_oc.add_argument("json_file", help="Path to OpenCode session export JSON file")
+    p_export_oc.add_argument("--output", help="Write to file instead of stdout")
+    p_export_oc.set_defaults(func=cmd_export_opencode)
+
+    # archive-opencode
+    p_archive_oc = subparsers.add_parser("archive-opencode", help="Archive OpenCode session to RLM memory")
+    p_archive_oc.add_argument("json_file", help="Path to OpenCode session export JSON file")
+    p_archive_oc.add_argument("--cwd", help="Working directory for project name detection")
+    p_archive_oc.set_defaults(func=cmd_archive_opencode)
 
     args = parser.parse_args()
     args.func(args)

--- a/rlm/export.py
+++ b/rlm/export.py
@@ -252,24 +252,24 @@ def _parse_entries(jsonl_path, is_openclaw):
     return entries
 
 
-def export_session(jsonl_path, output_path=None):
-    """Convert a session JSONL to a compressed conversation transcript.
+def _compress_and_format(parsed_entries, source_label, output_path=None):
+    """Shared compression pipeline for any parsed session format.
 
-    Supports both Claude Code and OpenClaw JSONL session formats.
-    Auto-detects format by checking first line for OpenClaw's session header.
+    Takes a list of (role, timestamp, content) tuples — the unified format
+    produced by _parse_entries() or opencode_export._parse_opencode_messages() —
+    and runs the full compression/dedup/formatting pipeline.
 
     Args:
-        jsonl_path: Path to a Claude Code or OpenClaw .jsonl session file.
+        parsed_entries: List of (role, timestamp, content) tuples.
+        source_label: Label for the transcript header (e.g., file path).
         output_path: If provided, write to this file. Otherwise return text.
 
     Returns:
-        The exported transcript as a string.
+        The compressed transcript as a string.
     """
-    is_openclaw = _detect_openclaw_format(jsonl_path)
-    parsed = _parse_entries(jsonl_path, is_openclaw)
     messages = []
 
-    for role, timestamp, content in parsed:
+    for role, timestamp, content in parsed_entries:
         result = extract_text_from_content(content)
 
         # Handle both old format (string) and new format (texts, tool_calls)
@@ -377,7 +377,7 @@ def export_session(jsonl_path, output_path=None):
     # Format output — compact headers
     output_lines = []
     output_lines.append(f"# Session Transcript ({len(compressed)} messages)")
-    output_lines.append(f"# Source: {jsonl_path}")
+    output_lines.append(f"# Source: {source_label}")
     output_lines.append("")
 
     for msg in compressed:
@@ -397,3 +397,21 @@ def export_session(jsonl_path, output_path=None):
             f.write(output_text)
 
     return output_text
+
+
+def export_session(jsonl_path, output_path=None):
+    """Convert a session JSONL to a compressed conversation transcript.
+
+    Supports both Claude Code and OpenClaw JSONL session formats.
+    Auto-detects format by checking first line for OpenClaw's session header.
+
+    Args:
+        jsonl_path: Path to a Claude Code or OpenClaw .jsonl session file.
+        output_path: If provided, write to this file. Otherwise return text.
+
+    Returns:
+        The exported transcript as a string.
+    """
+    is_openclaw = _detect_openclaw_format(jsonl_path)
+    parsed = _parse_entries(jsonl_path, is_openclaw)
+    return _compress_and_format(parsed, source_label=jsonl_path, output_path=output_path)

--- a/rlm/opencode_export.py
+++ b/rlm/opencode_export.py
@@ -1,0 +1,159 @@
+"""Parse OpenCode session exports into compressed transcripts.
+
+OpenCode exports sessions as a single JSON object (not JSONL):
+
+    {
+      "info": { "id": "...", "directory": "...", "title": "...",
+                "time": { "created": <epoch_ms> } },
+      "messages": [
+        { "info": { "role": "user"|"assistant", "time": {...} },
+          "parts": [{ "type": "text", "content": "..." }, ...] }
+      ]
+    }
+
+This module parses that format into the (role, timestamp, content) tuples
+that export._compress_and_format() expects, then runs the shared pipeline.
+"""
+
+import json
+from datetime import datetime, timezone
+
+
+def _epoch_ms_to_iso(epoch_ms):
+    """Convert epoch milliseconds to ISO 8601 string."""
+    if not epoch_ms:
+        return ""
+    try:
+        dt = datetime.fromtimestamp(epoch_ms / 1000, tz=timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    except (ValueError, TypeError, OSError):
+        return ""
+
+
+def _parse_opencode_parts(parts):
+    """Convert OpenCode message parts to the content-block format.
+
+    Maps OpenCode part types to the format extract_text_from_content() handles:
+      - text.content → {"type": "text", "text": ...}
+      - tool-invocation → {"type": "tool_use", "name": ..., "input": ...}
+      - tool-result → {"type": "tool_result"} (skipped by extract_text_from_content)
+      - reasoning → skipped entirely (like thinking blocks)
+
+    Returns a list of content blocks.
+    """
+    blocks = []
+    for part in parts:
+        ptype = part.get("type", "")
+
+        if ptype == "text":
+            text = part.get("content", "") or part.get("text", "")
+            if text:
+                blocks.append({"type": "text", "text": text})
+
+        elif ptype == "tool-invocation":
+            tool_name = part.get("toolName", "") or part.get("name", "unknown")
+            tool_input = part.get("input", {}) or part.get("args", {})
+            # Normalize tool_input — OpenCode may serialize as string
+            if isinstance(tool_input, str):
+                try:
+                    tool_input = json.loads(tool_input)
+                except (json.JSONDecodeError, TypeError):
+                    tool_input = {"raw": tool_input}
+            blocks.append({
+                "type": "tool_use",
+                "name": tool_name,
+                "input": tool_input,
+            })
+
+        elif ptype == "tool-result":
+            # Skip tool results (same as Claude Code's tool_result handling)
+            blocks.append({"type": "tool_result"})
+
+        elif ptype == "reasoning":
+            # Skip reasoning blocks (same as thinking blocks)
+            pass
+
+        # Other unknown types are silently ignored
+
+    return blocks
+
+
+def _parse_opencode_messages(data):
+    """Parse OpenCode JSON export into (role, timestamp, content) tuples.
+
+    Args:
+        data: Parsed JSON dict from an OpenCode export file.
+
+    Returns:
+        List of (role, timestamp, content) tuples compatible with
+        export._compress_and_format().
+    """
+    entries = []
+    messages = data.get("messages", [])
+
+    for msg in messages:
+        info = msg.get("info", {})
+        role = info.get("role", "")
+
+        # Skip non-user/assistant roles (e.g., "system")
+        if role not in ("user", "assistant"):
+            continue
+
+        # Extract timestamp — try info.time.created (epoch ms), then info.createdAt
+        time_info = info.get("time", {})
+        created_ms = time_info.get("created") or time_info.get("createdAt")
+        timestamp = _epoch_ms_to_iso(created_ms) if created_ms else ""
+
+        # Convert parts to content blocks
+        parts = msg.get("parts", [])
+        content = _parse_opencode_parts(parts)
+
+        if content:
+            entries.append((role, timestamp, content))
+
+    return entries
+
+
+def export_opencode_session(json_path, output_path=None):
+    """Convert an OpenCode JSON export to a compressed transcript.
+
+    Args:
+        json_path: Path to an OpenCode session export JSON file.
+        output_path: If provided, write to this file. Otherwise return text.
+
+    Returns:
+        The compressed transcript as a string.
+    """
+    from rlm.export import _compress_and_format
+
+    with open(json_path, "r") as f:
+        data = json.load(f)
+
+    parsed = _parse_opencode_messages(data)
+    return _compress_and_format(parsed, source_label=json_path, output_path=output_path)
+
+
+def get_session_id(data):
+    """Extract the session ID from an OpenCode export.
+
+    Args:
+        data: Parsed JSON dict from an OpenCode export file.
+
+    Returns:
+        Session ID string, or None if not found.
+    """
+    info = data.get("info", {})
+    return info.get("id")
+
+
+def get_session_directory(data):
+    """Extract the working directory from an OpenCode export.
+
+    Args:
+        data: Parsed JSON dict from an OpenCode export file.
+
+    Returns:
+        Directory path string, or None if not found.
+    """
+    info = data.get("info", {})
+    return info.get("directory")

--- a/tests/fixtures/opencode_export_sample.json
+++ b/tests/fixtures/opencode_export_sample.json
@@ -1,0 +1,173 @@
+{
+  "info": {
+    "id": "abc123-def456-ghi789",
+    "directory": "/Users/dev/projects/my-app",
+    "title": "Fix authentication bug",
+    "time": {
+      "created": 1709500000000
+    }
+  },
+  "messages": [
+    {
+      "info": {
+        "role": "user",
+        "time": {
+          "created": 1709500000000
+        }
+      },
+      "parts": [
+        {
+          "type": "text",
+          "content": "Can you help me fix the authentication bug in the login flow?"
+        }
+      ]
+    },
+    {
+      "info": {
+        "role": "assistant",
+        "time": {
+          "created": 1709500010000
+        }
+      },
+      "parts": [
+        {
+          "type": "reasoning",
+          "content": "Let me think about the authentication flow..."
+        },
+        {
+          "type": "text",
+          "content": "I'll look at the authentication code to find the issue."
+        },
+        {
+          "type": "tool-invocation",
+          "toolName": "Read",
+          "input": {
+            "file_path": "/Users/dev/projects/my-app/src/auth.ts"
+          }
+        }
+      ]
+    },
+    {
+      "info": {
+        "role": "assistant",
+        "time": {
+          "created": 1709500011000
+        }
+      },
+      "parts": [
+        {
+          "type": "tool-result",
+          "content": "export function login(username: string, password: string) {\n  // bug: missing await\n  const result = validateCredentials(username, password);\n  return result;\n}"
+        }
+      ]
+    },
+    {
+      "info": {
+        "role": "assistant",
+        "time": {
+          "created": 1709500020000
+        }
+      },
+      "parts": [
+        {
+          "type": "text",
+          "content": "Found the bug! The `validateCredentials` call is missing an `await`. Since it returns a Promise, the function returns a pending Promise instead of the actual result."
+        },
+        {
+          "type": "tool-invocation",
+          "toolName": "Edit",
+          "input": {
+            "file_path": "/Users/dev/projects/my-app/src/auth.ts"
+          }
+        }
+      ]
+    },
+    {
+      "info": {
+        "role": "user",
+        "time": {
+          "created": 1709500030000
+        }
+      },
+      "parts": [
+        {
+          "type": "text",
+          "content": "ok"
+        }
+      ]
+    },
+    {
+      "info": {
+        "role": "assistant",
+        "time": {
+          "created": 1709500040000
+        }
+      },
+      "parts": [
+        {
+          "type": "text",
+          "content": "The fix has been applied. The login function now properly awaits the validateCredentials call."
+        }
+      ]
+    },
+    {
+      "info": {
+        "role": "user",
+        "time": {
+          "created": 1709500050000
+        }
+      },
+      "parts": [
+        {
+          "type": "text",
+          "content": "Can you also run the tests?"
+        }
+      ]
+    },
+    {
+      "info": {
+        "role": "assistant",
+        "time": {
+          "created": 1709500060000
+        }
+      },
+      "parts": [
+        {
+          "type": "tool-invocation",
+          "toolName": "Bash",
+          "input": {
+            "command": "npm test"
+          }
+        }
+      ]
+    },
+    {
+      "info": {
+        "role": "assistant",
+        "time": {
+          "created": 1709500061000
+        }
+      },
+      "parts": [
+        {
+          "type": "tool-result",
+          "content": "PASS src/auth.test.ts\n  Authentication\n    \u2713 login succeeds with valid credentials (23ms)\n    \u2713 login fails with invalid credentials (12ms)\n\nTest Suites: 1 passed, 1 total\nTests: 2 passed, 2 total"
+        }
+      ]
+    },
+    {
+      "info": {
+        "role": "assistant",
+        "time": {
+          "created": 1709500070000
+        }
+      },
+      "parts": [
+        {
+          "type": "text",
+          "content": "All tests pass! The authentication fix is working correctly."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_archive_opencode.py
+++ b/tests/test_archive_opencode.py
@@ -1,0 +1,161 @@
+"""Tests for archive_opencode_session() — OpenCode session archival."""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+SAMPLE_EXPORT = os.path.join(FIXTURES_DIR, "opencode_export_sample.json")
+
+
+class TestArchiveOpencodeSession(unittest.TestCase):
+    @patch("rlm.archive.get_project_name", return_value="test-project")
+    @patch("rlm.archive.smart_remember")
+    @patch("rlm.archive.memory")
+    def test_basic_archival(self, mock_memory, mock_smart_remember, mock_proj):
+        """Archiving a valid session should call smart_remember with correct params."""
+        mock_smart_remember.return_value = {
+            "summary_id": "m_test123",
+            "tags": ["conversation", "opencode"],
+            "facts_count": 2,
+        }
+
+        from rlm.archive import archive_opencode_session
+
+        result = archive_opencode_session(SAMPLE_EXPORT, cwd="/tmp/test-project")
+
+        self.assertTrue(result)
+        mock_smart_remember.assert_called_once()
+
+        call_kwargs = mock_smart_remember.call_args[1]
+        self.assertEqual(call_kwargs["source"], "session")
+        self.assertEqual(call_kwargs["source_name"], "opencode:abc123-def456-ghi789")
+        self.assertIn("opencode", call_kwargs["user_tags"])
+        self.assertIn("conversation", call_kwargs["user_tags"])
+        self.assertTrue(call_kwargs["dedup"])
+        self.assertIn("OpenCode", call_kwargs["label"])
+
+    @patch("rlm.archive.get_project_name", return_value="my-project")
+    @patch("rlm.archive.smart_remember")
+    @patch("rlm.archive.memory")
+    def test_project_name_from_cwd(self, mock_memory, mock_smart_remember, mock_proj):
+        """When cwd is provided, project name should come from get_project_name(cwd)."""
+        mock_smart_remember.return_value = {
+            "summary_id": "m_test", "tags": [], "facts_count": 0,
+        }
+
+        from rlm.archive import archive_opencode_session
+
+        archive_opencode_session(SAMPLE_EXPORT, cwd="/tmp/my-project")
+
+        # get_project_name called with the cwd
+        mock_proj.assert_called_with(cwd="/tmp/my-project")
+
+        call_kwargs = mock_smart_remember.call_args[1]
+        self.assertIn("my-project", call_kwargs["user_tags"])
+
+    @patch("rlm.archive.get_project_name", return_value="my-app")
+    @patch("rlm.archive.smart_remember")
+    @patch("rlm.archive.memory")
+    def test_project_name_from_json_directory(self, mock_memory, mock_smart_remember, mock_proj):
+        """When no cwd, project name should come from JSON info.directory."""
+        mock_smart_remember.return_value = {
+            "summary_id": "m_test", "tags": [], "facts_count": 0,
+        }
+
+        from rlm.archive import archive_opencode_session
+
+        archive_opencode_session(SAMPLE_EXPORT, cwd=None)
+
+        # get_project_name called with the JSON directory
+        mock_proj.assert_called_with(cwd="/Users/dev/projects/my-app")
+
+        call_kwargs = mock_smart_remember.call_args[1]
+        self.assertIn("my-app", call_kwargs["user_tags"])
+
+    @patch("rlm.archive.get_project_name", return_value="unknown")
+    @patch("rlm.archive.smart_remember")
+    @patch("rlm.archive.memory")
+    def test_empty_session_skipped(self, mock_memory, mock_smart_remember, mock_proj):
+        """Empty session (no messages) should return False."""
+        data = {"info": {"id": "empty-session"}, "messages": []}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            json_path = f.name
+
+        from rlm.archive import archive_opencode_session
+
+        try:
+            result = archive_opencode_session(json_path)
+            self.assertFalse(result)
+            mock_smart_remember.assert_not_called()
+        finally:
+            os.unlink(json_path)
+
+    @patch("rlm.archive.smart_remember")
+    @patch("rlm.archive.memory")
+    def test_no_session_id_skipped(self, mock_memory, mock_smart_remember):
+        """Session without an ID should return False."""
+        data = {
+            "info": {},
+            "messages": [
+                {"info": {"role": "user", "time": {"created": 1709500000000}},
+                 "parts": [{"type": "text", "content": "hello"}]},
+            ],
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            json_path = f.name
+
+        from rlm.archive import archive_opencode_session
+
+        try:
+            result = archive_opencode_session(json_path)
+            self.assertFalse(result)
+            mock_smart_remember.assert_not_called()
+        finally:
+            os.unlink(json_path)
+
+    @patch("rlm.archive.get_project_name", return_value="my-app")
+    @patch("rlm.archive.smart_remember")
+    @patch("rlm.archive.memory")
+    def test_dedup_uses_session_id(self, mock_memory, mock_smart_remember, mock_proj):
+        """Archiving twice with same session ID should use dedup=True."""
+        mock_smart_remember.return_value = {
+            "summary_id": "m_first", "tags": [], "facts_count": 0,
+        }
+
+        from rlm.archive import archive_opencode_session
+
+        archive_opencode_session(SAMPLE_EXPORT)
+        archive_opencode_session(SAMPLE_EXPORT)
+
+        # Both calls should use dedup=True
+        for call in mock_smart_remember.call_args_list:
+            self.assertTrue(call[1]["dedup"])
+            self.assertEqual(call[1]["source_name"], "opencode:abc123-def456-ghi789")
+
+    @patch("rlm.archive.get_project_name", return_value="my-app")
+    @patch("rlm.archive.smart_remember")
+    @patch("rlm.archive.memory")
+    def test_transcript_passed_to_smart_remember(self, mock_memory, mock_smart_remember, mock_proj):
+        """The compressed transcript content should be passed to smart_remember."""
+        mock_smart_remember.return_value = {
+            "summary_id": "m_test", "tags": [], "facts_count": 0,
+        }
+
+        from rlm.archive import archive_opencode_session
+
+        archive_opencode_session(SAMPLE_EXPORT)
+
+        call_kwargs = mock_smart_remember.call_args[1]
+        content = call_kwargs["content"]
+        # Should contain the compressed transcript
+        self.assertIn("Session Transcript", content)
+        self.assertIn("authentication bug", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_opencode_export.py
+++ b/tests/test_opencode_export.py
@@ -1,0 +1,251 @@
+"""Tests for OpenCode session export parsing and compression."""
+
+import json
+import os
+import tempfile
+import unittest
+
+from rlm.opencode_export import (
+    _epoch_ms_to_iso,
+    _parse_opencode_messages,
+    _parse_opencode_parts,
+    export_opencode_session,
+    get_session_directory,
+    get_session_id,
+)
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+SAMPLE_EXPORT = os.path.join(FIXTURES_DIR, "opencode_export_sample.json")
+
+
+class TestEpochMsToIso(unittest.TestCase):
+    def test_valid_timestamp(self):
+        # 2024-03-04T00:00:00Z
+        result = _epoch_ms_to_iso(1709510400000)
+        self.assertIn("2024-03-04", result)
+
+    def test_zero_returns_empty(self):
+        self.assertEqual(_epoch_ms_to_iso(0), "")
+
+    def test_none_returns_empty(self):
+        self.assertEqual(_epoch_ms_to_iso(None), "")
+
+    def test_invalid_returns_empty(self):
+        self.assertEqual(_epoch_ms_to_iso("not-a-number"), "")
+
+
+class TestParseOpencodeParts(unittest.TestCase):
+    def test_text_part(self):
+        parts = [{"type": "text", "content": "Hello world"}]
+        blocks = _parse_opencode_parts(parts)
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0]["type"], "text")
+        self.assertEqual(blocks[0]["text"], "Hello world")
+
+    def test_text_with_text_key(self):
+        """Some OpenCode versions may use 'text' instead of 'content'."""
+        parts = [{"type": "text", "text": "Hello"}]
+        blocks = _parse_opencode_parts(parts)
+        self.assertEqual(blocks[0]["text"], "Hello")
+
+    def test_tool_invocation(self):
+        parts = [{"type": "tool-invocation", "toolName": "Bash", "input": {"command": "ls"}}]
+        blocks = _parse_opencode_parts(parts)
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0]["type"], "tool_use")
+        self.assertEqual(blocks[0]["name"], "Bash")
+        self.assertEqual(blocks[0]["input"]["command"], "ls")
+
+    def test_tool_invocation_string_input(self):
+        """Tool input may be a JSON string."""
+        parts = [{"type": "tool-invocation", "toolName": "Read", "input": '{"file_path": "/tmp/f"}'}]
+        blocks = _parse_opencode_parts(parts)
+        self.assertEqual(blocks[0]["input"]["file_path"], "/tmp/f")
+
+    def test_tool_result_produces_skip_block(self):
+        parts = [{"type": "tool-result", "content": "some output"}]
+        blocks = _parse_opencode_parts(parts)
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0]["type"], "tool_result")
+
+    def test_reasoning_skipped(self):
+        parts = [{"type": "reasoning", "content": "thinking..."}]
+        blocks = _parse_opencode_parts(parts)
+        self.assertEqual(len(blocks), 0)
+
+    def test_unknown_type_skipped(self):
+        parts = [{"type": "some-future-type", "data": "ignored"}]
+        blocks = _parse_opencode_parts(parts)
+        self.assertEqual(len(blocks), 0)
+
+    def test_mixed_parts(self):
+        parts = [
+            {"type": "reasoning", "content": "thinking..."},
+            {"type": "text", "content": "Here's what I found."},
+            {"type": "tool-invocation", "toolName": "Bash", "input": {"command": "git status"}},
+            {"type": "tool-result", "content": "on branch main"},
+        ]
+        blocks = _parse_opencode_parts(parts)
+        # reasoning skipped, text + tool_use + tool_result = 3
+        self.assertEqual(len(blocks), 3)
+        self.assertEqual(blocks[0]["type"], "text")
+        self.assertEqual(blocks[1]["type"], "tool_use")
+        self.assertEqual(blocks[2]["type"], "tool_result")
+
+    def test_empty_text_skipped(self):
+        parts = [{"type": "text", "content": ""}]
+        blocks = _parse_opencode_parts(parts)
+        self.assertEqual(len(blocks), 0)
+
+
+class TestParseOpencodeMessages(unittest.TestCase):
+    def test_basic_messages(self):
+        data = {
+            "info": {"id": "test"},
+            "messages": [
+                {"info": {"role": "user", "time": {"created": 1709500000000}},
+                 "parts": [{"type": "text", "content": "hello"}]},
+                {"info": {"role": "assistant", "time": {"created": 1709500010000}},
+                 "parts": [{"type": "text", "content": "hi there"}]},
+            ],
+        }
+        entries = _parse_opencode_messages(data)
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0][0], "user")
+        self.assertEqual(entries[1][0], "assistant")
+        # Timestamps should be ISO strings
+        self.assertIn("2024-03-03", entries[0][1])
+
+    def test_system_role_skipped(self):
+        data = {
+            "info": {"id": "test"},
+            "messages": [
+                {"info": {"role": "system", "time": {"created": 1709500000000}},
+                 "parts": [{"type": "text", "content": "system prompt"}]},
+                {"info": {"role": "user", "time": {"created": 1709500001000}},
+                 "parts": [{"type": "text", "content": "hello"}]},
+            ],
+        }
+        entries = _parse_opencode_messages(data)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0][0], "user")
+
+    def test_empty_parts_skipped(self):
+        data = {
+            "info": {"id": "test"},
+            "messages": [
+                {"info": {"role": "user", "time": {"created": 1709500000000}},
+                 "parts": []},
+            ],
+        }
+        entries = _parse_opencode_messages(data)
+        self.assertEqual(len(entries), 0)
+
+    def test_no_messages(self):
+        data = {"info": {"id": "test"}, "messages": []}
+        entries = _parse_opencode_messages(data)
+        self.assertEqual(len(entries), 0)
+
+
+class TestExportOpencodeSession(unittest.TestCase):
+    def test_sample_fixture(self):
+        result = export_opencode_session(SAMPLE_EXPORT)
+        self.assertIn("Session Transcript", result)
+        self.assertIn("fix the authentication bug", result)
+        self.assertIn("Found the bug", result)
+        # Reasoning should NOT appear
+        self.assertNotIn("Let me think about", result)
+        # Tool result raw content should NOT appear (the test file output)
+        self.assertNotIn("PASS src/auth.test.ts", result)
+        # Trivial confirmation should be collapsed
+        self.assertIn("[User confirmed]", result)
+
+    def test_output_to_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            out_path = f.name
+        try:
+            result = export_opencode_session(SAMPLE_EXPORT, output_path=out_path)
+            with open(out_path) as f:
+                written = f.read()
+            self.assertEqual(result, written)
+        finally:
+            os.unlink(out_path)
+
+    def test_empty_session(self):
+        data = {"info": {"id": "empty"}, "messages": []}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            json_path = f.name
+        try:
+            result = export_opencode_session(json_path)
+            self.assertIn("0 messages", result)
+        finally:
+            os.unlink(json_path)
+
+    def test_tool_only_assistant_message(self):
+        """Assistant message with only tool calls should be compressed."""
+        data = {
+            "info": {"id": "test"},
+            "messages": [
+                {"info": {"role": "user", "time": {"created": 1709500000000}},
+                 "parts": [{"type": "text", "content": "run tests"}]},
+                {"info": {"role": "assistant", "time": {"created": 1709500010000}},
+                 "parts": [
+                     {"type": "tool-invocation", "toolName": "Bash",
+                      "input": {"command": "npm test"}},
+                 ]},
+            ],
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            json_path = f.name
+        try:
+            result = export_opencode_session(json_path)
+            self.assertIn("[Ran 1 tools: Bash]", result)
+        finally:
+            os.unlink(json_path)
+
+    def test_reasoning_only_message_excluded(self):
+        """Assistant message with only reasoning parts should be excluded."""
+        data = {
+            "info": {"id": "test"},
+            "messages": [
+                {"info": {"role": "user", "time": {"created": 1709500000000}},
+                 "parts": [{"type": "text", "content": "explain this"}]},
+                {"info": {"role": "assistant", "time": {"created": 1709500010000}},
+                 "parts": [{"type": "reasoning", "content": "deep thoughts..."}]},
+                {"info": {"role": "assistant", "time": {"created": 1709500020000}},
+                 "parts": [{"type": "text", "content": "Here is the explanation."}]},
+            ],
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            json_path = f.name
+        try:
+            result = export_opencode_session(json_path)
+            self.assertNotIn("deep thoughts", result)
+            self.assertIn("Here is the explanation", result)
+        finally:
+            os.unlink(json_path)
+
+
+class TestGetSessionMetadata(unittest.TestCase):
+    def test_get_session_id(self):
+        with open(SAMPLE_EXPORT) as f:
+            data = json.load(f)
+        self.assertEqual(get_session_id(data), "abc123-def456-ghi789")
+
+    def test_get_session_directory(self):
+        with open(SAMPLE_EXPORT) as f:
+            data = json.load(f)
+        self.assertEqual(get_session_directory(data), "/Users/dev/projects/my-app")
+
+    def test_missing_id(self):
+        self.assertIsNone(get_session_id({"info": {}}))
+
+    def test_missing_directory(self):
+        self.assertIsNone(get_session_directory({"info": {}}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #69

Adds full OpenCode integration to RLM, achieving parity with the Claude Code integration:
- **MCP tools** — already work via the existing server; installer registers it in OpenCode config
- **Automatic session archival** — OpenCode plugin triggers archival on compaction and idle
- **Context injection** — previous session memories injected into system prompt

### Architecture

A thin JS/TS plugin (`opencode/rlm-plugin.ts`) shells out to the existing Python CLI, keeping all memory logic in Python. The OpenCode JSON session format is parsed by a new module (`rlm/opencode_export.py`) and fed through the same compression pipeline used for Claude Code and OpenClaw sessions.

### Changes

| File | Action | Description |
|---|---|---|
| `rlm/export.py` | Modified | Extract `_compress_and_format()` — shared compression pipeline |
| `rlm/opencode_export.py` | **New** | OpenCode JSON parser (parts→blocks, timestamps, full export) |
| `rlm/archive.py` | Modified | Add `archive_opencode_session()` with DB-level dedup |
| `rlm/cli.py` | Modified | Add `export-opencode` and `archive-opencode` subcommands |
| `opencode/rlm-plugin.ts` | **New** | JS/TS plugin with 3 hooks (context, compacting, idle) |
| `install-opencode.sh` | **New** | Installer (uv sync + plugin copy + MCP registration) |
| `tests/test_opencode_export.py` | **New** | 26 tests for export parsing |
| `tests/test_archive_opencode.py` | **New** | 7 tests for archival pipeline |
| `tests/fixtures/opencode_export_sample.json` | **New** | Test fixture |

### Test results

167 passed, 1 skipped (all existing + 33 new OpenCode tests)

## Test plan

- [x] Unit tests: `uv run python -m pytest tests/test_opencode_export.py tests/test_archive_opencode.py -v` (33 pass)
- [x] Full test suite: `uv run python -m pytest tests/ -v` (167 pass, 1 skipped)
- [x] CLI smoke test: `uv run rlm export-opencode tests/fixtures/opencode_export_sample.json` produces compressed transcript
- [ ] Install and verify with OpenCode (manual — `./install-opencode.sh` + `opencode mcp list`)